### PR TITLE
Fix for UnicodeDecodeError on image upload

### DIFF
--- a/django_b2storage/backblaze_b2.py
+++ b/django_b2storage/backblaze_b2.py
@@ -1,13 +1,17 @@
 import json
 import mimetypes
 import hashlib
-from urllib.request import Request, urlopen
+import requests
+import os
+
+from urllib2 import Request, urlopen, quote
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 
-from .connectioninfo import ConnectionInfo, decode, encode
+from .connectioninfo import ConnectionInfo, encode
+
 
 
 @deconstructible
@@ -22,13 +26,12 @@ class B2Storage(Storage):
         headers = {
             'Authorization' : self.connection.auth_token
         }
-        request = Request(url, None, headers)
-        response = urlopen(request)
-        response_data = json.loads(decode(response.read()))
-        response.close()
+        request = requests.post(url, data=None, headers=headers)
+        response_data = json.loads(request.content)
         return ContentFile(response_data)
 
     def _save(self, name, content):
+        name = os.path.basename(name)
         upload_data = self.connection.upload_data
         file_data = content.read()
         file_sha1 = hashlib.sha1(file_data).hexdigest()
@@ -38,32 +41,28 @@ class B2Storage(Storage):
         else:
             content_type = mimetypes.guess_type(name)[0]
         headers = {
-            'Authorization' : upload_data['authorizationToken'],
-            'X-Bz-File-Name' :  name,
-            'Content-Type' : content_type,
-            'X-Bz-Content-Sha1' : file_sha1
+            'Authorization' : quote(upload_data['authorizationToken'].encode('utf-8')),
+            'X-Bz-File-Name' : quote(name.encode('utf-8')),
+            'Content-Type' : quote(content_type.encode('utf-8')),
+            'X-Bz-Content-Sha1' : quote(file_sha1.encode('utf-8')),
         }
-        request = Request(upload_data['uploadUrl'], file_data, headers)
-        response = urlopen(request)
-        response_data = json.loads(decode(response.read()))
+        request = requests.post(upload_data['uploadUrl'], data = file_data, headers = headers)
+        response_data = json.loads(request.content)
         # Add file_name:file_id to our dict
         file_id = response_data['fileId']
         name = response_data['fileName']
         self.connection.name_id_dict[name] = file_id
-        response.close()
         return name
 
 
     def delete(self, name):
         file_id = self.connection.get_file_id(name)
-        request = Request(
+        request = requests.post(
             '%s/b2api/v1/b2_delete_file_version' % self.connection.api_url,
-            encode(json.dumps({ 'fileName' : name, 'fileId' : file_id })),
+            data = encode(json.dumps({ 'fileName' : name, 'fileId' : file_id })),
             headers = { 'Authorization': self.connection.auth_token }
         )
-        response = urlopen(request)
-        json.loads(decode(response.read()))
-        response.close()
+        json.loads(request.content)
         del self.connection.name_id_dict[name]
 
     def url(self, name):

--- a/django_b2storage/connectioninfo.py
+++ b/django_b2storage/connectioninfo.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from urllib.request import Request, urlopen
+from urllib2 import Request, urlopen
 import datetime
 
 from django.conf import settings
@@ -45,7 +45,7 @@ class ConnectionInfo():
             )
             response = urlopen(request)
             self._auth_request_time = datetime.datetime.now() # reset time
-            self._auth_data = json.loads(decode(response.read()))
+            self._auth_data = json.loads(response.read())
             response.close()
         return self._auth_data
 


### PR DESCRIPTION
This is a fix for a number of encoding and decoding errors I was running into on uploading images - using the [requests library](http://docs.python-requests.org/en/master/) rather than urllib.Request bypassed a UnicodeDecodeError when passing the file data. I also used [os.path.basename](https://docs.python.org/2/library/os.path.html#os.path.basename) on file names in _save, as backblaze was throwing 401 errors for names containing '/' in filepaths. Lastly, I updated headers to use the recommended encoding method from [backblaze docs](https://www.backblaze.com/b2/docs/string_encoding.html) to ensure there were no similar encoding errors here too.

This is my first pull request on a project so I apologise in advance if I've got the process wrong, but would appreciate any thoughts on my approach. Thanks for the excellent package, the integration of alternative file storage options is much appreciated.